### PR TITLE
docker 相关

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM golang:alpine
+FROM golang:latest
 COPY . /app
 WORKDIR /app
-ENV GO111MODULE=on
-ENV GOPROXY=https://goproxy.cn
+ENV GO111MODULE=on \
+    GOPROXY=https://goproxy.cn
 RUN go build
 EXPOSE 11111
 CMD ./bt_crawler

--- a/runserver.sh
+++ b/runserver.sh
@@ -3,4 +3,4 @@
 
 docker image rm bt_crawler
 docker image build -t bt_crawler .
-docker run --rm -p 11112:11111 bt_crawler
+docker run -it --rm --name bt_crawler -p 11112:11111 bt_crawler


### PR DESCRIPTION
- github.com/mattn/go-sqlite3
- github.com/anacrolix/go-libutp
- gopkg.in/confluentinc/confluent-kafka-go.v1/kafka
如上3个包依赖`gcc`，所以更换了docker基础镜像
给docker运行命令加上了`-it`参数，解决`Ctrl+c`无效问题
给运行容器指定了名称